### PR TITLE
Default PASSED_ARGUMENT to current directory

### DIFF
--- a/datagrip
+++ b/datagrip
@@ -14,7 +14,7 @@
 
 # http://biercoff.com/readlink-f-unrecognized-option-problem-solution-on-mac/ link to article regarding readlink where I found these fixes found above
 
-PASSED_ARGUMENT=$1
+PASSED_ARGUMENT="${1:-.}"
 
 # Not sure if this is needed anymore but doesn't seem to hurt any thing and gets
 # a fully qualified path

--- a/phpstorm
+++ b/phpstorm
@@ -14,7 +14,7 @@
 
 # http://biercoff.com/readlink-f-unrecognized-option-problem-solution-on-mac/ link to article regarding readlink where I found these fixes found above
 
-PASSED_ARGUMENT=$1
+PASSED_ARGUMENT="${1:-.}"
 
 # Not sure if this is needed anymore but doesn't seem to hurt any thing and gets
 # a fully qualified path

--- a/pycharm
+++ b/pycharm
@@ -14,7 +14,7 @@
 
 # http://biercoff.com/readlink-f-unrecognized-option-problem-solution-on-mac/ link to article regarding readlink where I found these fixes found above
 
-PASSED_ARGUMENT=$1
+PASSED_ARGUMENT="${1:-.}"
 
 # Not sure if this is needed anymore but doesn't seem to hurt any thing and gets
 # a fully qualified path

--- a/rider
+++ b/rider
@@ -14,7 +14,7 @@
 
 # open -na "Rider.app" --args "$@"  # original but didn't open the solution file
 
-PASSED_ARGUMENT=$1
+PASSED_ARGUMENT="${1:-.}"
 
 # Not sure if this is needed anymore but doesn't seem to hurt any thing and gets
 # a fully qualified path
@@ -25,7 +25,7 @@ fi
 
 if [ -d "${PASSED_ARGUMENT}" ];
 then 
-  SOLUTION=$(find $1 -type f -name "*.sln")
+  SOLUTION=$(find $PASSED_ARGUMENT -type f -name "*.sln")
   open -na "Rider.app" --args ${SOLUTION}
 elif [ -f "${PASSED_ARGUMENT}" ];
 then open -na "Rider.app" --args "$@"

--- a/webstorm
+++ b/webstorm
@@ -14,7 +14,7 @@
 
 # http://biercoff.com/readlink-f-unrecognized-option-problem-solution-on-mac/ link to article regarding readlink where I found these fixes found above
 
-PASSED_ARGUMENT=$1
+PASSED_ARGUMENT="${1:-.}"
 
 # Not sure if this is needed anymore but doesn't seem to hurt any thing and gets
 # a fully qualified path


### PR DESCRIPTION
### Description
 - When I'm in a directory and run one of the commands, I want it to assume it should check the current directory when no parameter is provided
 - We should retain the ability for a user to choose the current directory with `.`, so as to continue to allow the convention that VS Code uses. 